### PR TITLE
generate command

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,10 +4,83 @@
 
 `chef-acceptance` makes it easy to develop acceptance tests for a project. You can run any type of suites for your project (test-kitchen, pedant, chef provisioning, rspec, etc...) but it enforces a structure so that you can run all of your different acceptance tests in the same way. It also gives you a CLI interface so that you can build your tests without breaking your pipeline until they are ready.
 
-## Usage
+## Setup
 
-Add an `acceptance` directory to your project with the following directory structure:
+Create an `acceptance` directory to your project
+```
+mkdir acceptance
 
+cd acceptance
+```
+
+Generate a test suite
+```
+chef-acceptance generate my-test-suite
+```
+
+Output
+```
+acceptance
+├── my-test-suite
+│   ├── .acceptance
+│   │   └── acceptance-cookbook
+|   |       ├──.chef
+|   |       │   └── config.rb
+│   │       ├── metadata.rb
+│   │       └── recipes
+│   │           ├── destroy.rb
+│   │           ├── provision.rb
+│   │           └── verify.rb
+│   └── .gitignore
+
+```
+
+Now you can run your acceptance test phases
+```
+# chef-acceptance <command> <suite-name> [options]
+chef-acceptance provision my-test-suite
+chef-acceptance verify my-test-suite
+chef-acceptance destroy my-test-suite
+```
+
+```
+# Run the commands in sequence
+chef-acceptance test my-test-suite
+```
+
+## Commands
+
+`chef-acceptance provision <suite-name>`
+Runs the provision recipe for the given acceptance suite.
+
+`chef-acceptance verify <suite-name>`
+Runs the tests for the given acceptance suite.
+
+`chef-acceptance destroy <suite-name>`
+Destroy your acceptance setup.
+
+`chef-acceptance test <suite-name>`
+Runs the provision, verify, and destroy recipes for the given acceptance suite.
+
+`chef-acceptance generate <suite-name>`
+Generates acceptance test suite scaffold that you can modify.
+
+#### Not implemented
+
+Once your acceptance tests are strong you can add this to your build cookbook to run your tests in Chef Delivery:
+
+```
+chef_acceptance 'spincycle' do
+  acceptance_directory File.join(node['delivery']['project_workspace'], 'acceptance')
+  action :provision
+end
+
+chef_acceptance 'spincycle' do
+  action :verify
+end
+```
+
+## Example project
 ```
 acceptance
 ├── lamont-ci
@@ -36,51 +109,4 @@ acceptance
         └── default.rb
 ```
 
-You will notice that in this example, acceptance suites are using Test Kitchen.
-  But you are not tied to it. You can use any setup you'd like.
-
-Now you can run your acceptance tests as below:
-
-```
-# chef-acceptance <command> <suite-name> [options]
-chef-acceptance provision spincycle
-chef-acceptance verify spincycle
-chef-acceptance destroy spincycle
-
-# Run the commands in sequence
-chef-acceptance test spincycle
-```
-
-#### Not implemented
-
-Once your acceptance tests are strong you can add this to your build cookbook to run your tests in Chef Delivery:
-
-```
-chef_acceptance 'spincycle' do
-  acceptance_directory File.join(node['delivery']['project_workspace'], 'acceptance')
-  action :provision
-end
-
-chef_acceptance 'spincycle' do
-  action :verify
-end
-```
-
-## Options
-
-`chef-acceptance provision <suite-name>`
-Runs the provision recipe for the given acceptance suite.
-
-`chef-acceptance verify <suite-name>`
-Runs the tests for the given acceptance suite.
-
-`chef-acceptance destroy <suite-name>`
-Destroy your acceptance setup.
-
-`chef-acceptance test <suite-name>`
-Runs the provision, verify, and destroy recipes for the given acceptance suite.
-
-#### Not implemented
-
-`chef-acceptance generate <suite-name>`
-Generates a skeleton acceptance test suite that you can modify.
+You will notice that in this example, acceptance suites are using Test Kitchen. But you are not tied to it. You can use any setup you'd like.

--- a/lib/chef-acceptance/cli.rb
+++ b/lib/chef-acceptance/cli.rb
@@ -4,51 +4,47 @@ require 'chef-acceptance/version'
 
 module ChefAcceptance
   class Cli < Thor
-    ACCEPTANCE_DIR = '.acceptance'.freeze
-
     ACCEPTANCE_COOKBOOK_NAME = 'acceptance-cookbook'.freeze
+
+    CORE_ACCEPTANCE_COMMANDS = %w(destroy provision verify).freeze
 
     DESTROY_OPTIONS = %w(always never passing).freeze
 
     package_name 'chef-acceptance'
 
-    desc 'version', 'Print chef-acceptance version'
-    def version
-      puts ChefAcceptance::VERSION
-    end
-
     #
-    # Dynamically build core acceptance commands
+    # Create core acceptance commands
     #
-    %w(destroy provision verify).each do |command|
-      desc command, "Run #{command}"
+    CORE_ACCEPTANCE_COMMANDS.each do |command|
+      desc "#{command} TEST_SUITE", "Run #{command}"
       define_method(command) do |test_suite|
-        executable_installed! 'chef-client'
-        test_suite_exist! test_suite
+        chef_client_installed!
 
-        cookbook_dir = File.expand_path(File.join(test_suite, ACCEPTANCE_DIR, ACCEPTANCE_COOKBOOK_NAME))
-        config_file = File.join(cookbook_dir, '.chef', 'config.rb')
-        run_list = "#{ACCEPTANCE_COOKBOOK_NAME}::#{command}"
+        suite = TestSuite.new(test_suite)
 
-        chef_zero = Mixlib::ShellOut.new("chef-client -z -c #{config_file} -o #{run_list}", cwd: cookbook_dir, live_stream: $stdout)
+        suite.exist!
+
+        shellout = []
+        shellout << 'chef-client -z'
+        shellout << "-c #{File.expand_path(suite.chef_config_file)}"
+        shellout << "-o #{ACCEPTANCE_COOKBOOK_NAME}::#{command}"
+
+        chef_zero = Mixlib::ShellOut.new(shellout.join(' '),
+                                         cwd: suite.acceptance_cookbook_dir,
+                                         live_stream: $stdout)
         chef_zero.run_command
+
         abort "#{chef_zero.stdout}\n#{chef_zero.stderr}" if chef_zero.error?
       end
     end
 
-    #
-    # test command
-    # Calls provision, verify and destroy commands
-    #
-    desc 'test', 'Run provision, verify and destroy'
+    desc 'test TEST_SUITE [OPTIONS]', 'Run provision, verify and destroy'
     option :destroy,
+           banner: 'STRATEGY',
            aliases: '-d',
            default: 'passing',
            desc: "Destroy strategy to use after testing (#{DESTROY_OPTIONS.join(', ')})"
     def test(test_suite)
-      executable_installed! 'chef-client'
-      test_suite_exist! test_suite
-
       unless DESTROY_OPTIONS.include? options[:destroy]
         abort "destroy option must be one of: #{DESTROY_OPTIONS.join(', ')}"
       end
@@ -63,17 +59,46 @@ module ChefAcceptance
       end
     end
 
-    no_commands do
-      def test_suite_exist!(test_suite)
-        unless File.exist?(test_suite)
-          abort <<-EOS
-Could not find test suite '#{test_suite}' in the current working directory '#{Dir.pwd}'.
-Make sure to have a test suite with a '#{File.join(ACCEPTANCE_DIR, ACCEPTANCE_COOKBOOK_NAME)}' directory.
-EOS
-        end
+    desc 'generate NAME', 'Generate acceptance scaffolding'
+    def generate(name)
+      suite = TestSuite.new(name)
+
+      abort "Test suite '#{name}' already exists." if suite.exist?
+
+      [suite.acceptance_cookbook_dir, suite.chef_dir, suite.recipes_dir].each do |path|
+        FileUtils.mkpath path
       end
 
-      def executable_installed!(executable)
+      CORE_ACCEPTANCE_COMMANDS.each do |file|
+        FileUtils.touch(File.join(suite.recipes_dir, "#{file}.rb"))
+      end
+
+      File.write(File.join(suite.acceptance_cookbook_dir, 'metadata.rb'),
+        "name '#{ACCEPTANCE_COOKBOOK_NAME}'")
+
+      File.write(suite.chef_config_file,
+        "cookbook_path File.join(File.dirname(__FILE__), '..', '..')")
+
+      File.write(File.join(name, '.gitignore'),
+        "local-mode-cache/\nnodes/")
+
+      puts "Run `chef-acceptance test #{name}`"
+    end
+
+    desc 'version', 'Print chef-acceptance version'
+    def version
+      puts ChefAcceptance::VERSION
+    end
+
+    desc 'info', 'Print chef-acceptance information'
+    def info
+      puts "chef-acceptance version: #{ChefAcceptance::VERSION}"
+      client = executable_installed? 'chef-client'
+      puts "chef-client path: #{client ? client : "not found in #{ENV['PATH']}"}"
+    end
+
+    no_commands do
+      def executable_installed?(executable)
         exts = ENV['PATHEXT'] ? ENV['PATHEXT'].split(';') : ['']
         ENV['PATH'].split(File::PATH_SEPARATOR).each do |path|
           exts.each do |ext|
@@ -81,7 +106,46 @@ EOS
             return exe if File.executable?(exe) && !File.directory?(exe)
           end
         end
-        abort "#{executable} executable not installed"
+        false
+      end
+
+      def chef_client_installed!
+        unless executable_installed? 'chef-client'
+          abort "Could not find chef-client in #{ENV['PATH']}"
+        end
+      end
+
+      TestSuite = Struct.new(:name) do
+        # TODO: sanitize input
+
+        def exist?
+          File.exist?(name)
+        end
+
+        def exist!
+          unless self.exist?
+            abort <<-EOS
+  Could not find test suite '#{name}' in the current working \
+  directory '#{Dir.pwd}'.
+  EOS
+          end
+        end
+
+        def acceptance_cookbook_dir
+          File.join(name, '.acceptance', ACCEPTANCE_COOKBOOK_NAME)
+        end
+
+        def recipes_dir
+          File.join(acceptance_cookbook_dir, 'recipes')
+        end
+
+        def chef_dir
+          File.join(acceptance_cookbook_dir, '.chef')
+        end
+
+        def chef_config_file
+          File.join(chef_dir, 'config.rb')
+        end
       end
     end
   end

--- a/spec/cli_spec.rb
+++ b/spec/cli_spec.rb
@@ -150,9 +150,26 @@ context 'ChefAcceptance::Cli' do
     end
   end
 
-  context '#executable_installed!' do
+  context 'generate command' do
+    let(:command) { :generate }
+    let(:test_suite) { 'foo' }
+
+    it 'generates and runs' do
+      Dir.mktmpdir do |dir|
+        Dir.chdir(dir)
+        FileUtils.mkpath 'acceptance'
+        Dir.chdir 'acceptance'
+        expect(capture(:stdout) { cli.send(command, test_suite) }).to match(/chef-acceptance test #{test_suite}/)
+        expect { cli.send(command, test_suite) }.to raise_error(/Test suite '#{test_suite}' already exists./)
+        cli.options = { destroy: 'always' }
+        cli.send(:test, test_suite)
+      end
+    end
+  end
+
+  context '#executable_installed?' do
     it 'fails when not found' do
-      expect { cli.executable_installed! 'betterlucknexttime' }.to raise_error(/betterlucknexttime executable not installed/)
+      expect(cli.executable_installed?('betterlucknexttime')).to be false
     end
   end
 end


### PR DESCRIPTION
Simple dir and file generator for the acceptance scaffold.  Nothing fancy here.  

@jtimberman has made the request to add `generate` to the `chef` exec.  I think that is a good idea when we consider making chef-acceptance part of chef-dk (hopefully one day.) 

For now, I think keeping the generate command as part of `chef-acceptance` makes the most sense.

@sersut @schisamo