### PR TITLE
Run chef under a clean bundler environment so that chef-acceptance can be used as a gem with Gemfile.

### DIFF
--- a/lib/chef-acceptance/test_suite.rb
+++ b/lib/chef-acceptance/test_suite.rb
@@ -61,13 +61,15 @@ EOS
         shellout << "-o #{run_list.join(',')}"
       end
 
-      chef_zero = Mixlib::ShellOut.new(shellout.join(' '),
-                                      cwd: acceptance_cookbook_dir,
-                                      live_stream: $stdout)
+      Bundler.with_clean_env do
+        chef_zero = Mixlib::ShellOut.new(shellout.join(' '),
+                                        cwd: acceptance_cookbook_dir,
+                                        live_stream: $stdout)
 
-      chef_zero.run_command
+        chef_zero.run_command
 
-      fail "#{chef_zero.stdout}\n#{chef_zero.stderr}" if chef_zero.error?
+        fail "#{chef_zero.stdout}\n#{chef_zero.stderr}" if chef_zero.error?
+      end
     end
 
     def generate


### PR DESCRIPTION
Without this change when using chef-acceptance in a Gemfile I get this error:

```
/opt/chefdk/embedded/lib/ruby/gems/2.1.0/gems/bundler-1.10.6/lib/bundler/rubygems_integration.rb:292:in `block in replace_gem': chef is not part of the bundle. Add it to Gemfile. (Gem::LoadError)
	from /Users/serdar/.chefdk/gem/ruby/2.1.0/bin/chef-client:22:in `<main>'
/Users/serdar/chef/chef-acceptance/lib/chef-acceptance/test_suite.rb:72:in `run':  (RuntimeError)
/opt/chefdk/embedded/lib/ruby/gems/2.1.0/gems/bundler-1.10.6/lib/bundler/rubygems_integration.rb:292:in `block in replace_gem': chef is not part of the bundle. Add it to Gemfile. (Gem::LoadError)
```

This fixes above type of errors. /cc: @patrick-wright @jtimberman @schisamo 