### PR TITLE
Allow use of a shared cookbook path

### DIFF
--- a/lib/chef-acceptance/chef_runner.rb
+++ b/lib/chef-acceptance/chef_runner.rb
@@ -51,9 +51,15 @@ module ChefAcceptance
     end
 
     def chef_config_template
+      # Note: we include a .shared directory in the cookbook path in order to
+      # allow suites to share infrastructure. This is currently not supported for
+      # projects to use externally. There will eventually be a better way to do this.
       <<-EOS.gsub(/^\s+/, "")
-        cookbook_path '#{File.expand_path(File.join(acceptance_cookbook.root_dir, '..'))}'
-        node_path '#{File.expand_path(File.join(acceptance_cookbook.root_dir, 'nodes'))}'
+        cookbook_path [
+          #{File.expand_path('..', acceptance_cookbook.root_dir).inspect},
+          #{File.expand_path('../../../.shared', acceptance_cookbook.root_dir).inspect}
+        ]
+        node_path #{File.expand_path('nodes', acceptance_cookbook.root_dir).inspect}
         stream_execute_output true
       EOS
     end

--- a/spec/integration/chef_runner_spec.rb
+++ b/spec/integration/chef_runner_spec.rb
@@ -13,4 +13,26 @@ context ChefAcceptance::ChefRunner do
       expect(capture(:stdout) { runner.run! }).to match(/Running 'provision' recipe from the acceptance-cookbook in directory '.*foo'/)
     end
   end
+
+  it "calls run and picks up shared cookbooks" do
+    Dir.mktmpdir do |dir|
+      ChefAcceptance::AcceptanceCookbook.new(File.join(dir, "foo", ".acceptance")).generate
+      # Create an empty testme cookbook in .shared/testme
+      Dir.mkdir File.join(dir, ".shared")
+      Dir.mkdir File.join(dir, ".shared", "testme")
+      IO.write(File.join(dir, ".shared", "testme", "metadata.rb"), <<-EOM)
+        name "testme"
+      EOM
+      # Depend on the testme cookbook in the acceptance-cookbook
+      IO.write(File.join(dir, "foo", ".acceptance", "acceptance-cookbook", "metadata.rb"), <<-EOM)
+        name "acceptance-cookbook"
+        depends "testme"
+      EOM
+      Dir.chdir dir
+      test_suite = ChefAcceptance::TestSuite.new("foo")
+      runner = ChefAcceptance::ChefRunner.new(test_suite, "provision")
+
+      expect(capture(:stdout) { runner.run! }).to match(/Running 'provision' recipe from the acceptance-cookbook in directory '.*foo'/)
+    end
+  end
 end


### PR DESCRIPTION
Enable chef-acceptance to pull in a shared cookbook path.
This allows us to have common infrastructure used between multiple suites.

@sersut @patrick-wright @jkeiser 