### PR TITLE
Adding the logger class and its own specs

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -7,12 +7,12 @@ task default: :test
 
 desc "run unit tests"
 RSpec::Core::RakeTask.new(:unit) do |task|
-  task.pattern = "spec/chef-acceptance/*_spec.rb"
+  task.pattern = "spec/unit/**/*_spec.rb"
 end
 
 desc "run integration tests"
 RSpec::Core::RakeTask.new(:integration) do |task|
-  task.pattern = "spec/integration/*_spec.rb"
+  task.pattern = "spec/integration/**/*_spec.rb"
 end
 
 begin

--- a/lib/chef-acceptance/logger.rb
+++ b/lib/chef-acceptance/logger.rb
@@ -1,0 +1,58 @@
+require "logger"
+
+module ChefAcceptance
+  class Logger
+    attr_reader :log_directory
+    attr_reader :acceptance_logger
+    attr_reader :stdout_logger
+    attr_reader :suite_loggers
+
+    def initialize(base_dir = Dir.pwd)
+      @log_directory = File.join(base_dir, ".acceptance_logs")
+      @suite_loggers = []
+
+      # create the main logs directory
+      FileUtils.mkdir_p(log_directory)
+
+      @acceptance_logger = create_acceptance_logger
+      @stdout_logger = create_stdout_logger
+
+      log("Initialized acceptance logger...")
+    end
+
+    # logs given message to the acceptance logs and stdout
+    def log(message)
+      acceptance_logger.info(message)
+      stdout_logger.info(message)
+    end
+
+    private
+
+    def create_acceptance_logger
+      # auto-flush the log file and truncate the log file if it already exists
+      log_file = File.open(File.join(log_directory, "acceptance.log"),
+        File::WRONLY | File::TRUNC | File::CREAT)
+      log_file.sync = true
+
+      format_logger_for_acceptance(::Logger.new(log_file))
+    end
+
+    def create_stdout_logger
+      format_logger_for_acceptance(::Logger.new($stdout))
+    end
+
+    def format_logger_for_acceptance(logger)
+      logger.progname = "CHEF-ACCEPTANCE"
+      logger.formatter = proc { |severity, datetime, progname, msg|
+        "#{progname}::#{severity}::[#{datetime}] #{msg}\n"
+      }
+
+      logger
+    end
+
+    # def add_suite_logger(suite_name)
+    #   FileUtils.mkdir_p(File.join(log_directory, suite_name))
+    #   # create our suite_logger
+    # end
+  end
+end

--- a/spec/integration/acceptance_cookbook_spec.rb
+++ b/spec/integration/acceptance_cookbook_spec.rb
@@ -2,7 +2,7 @@ require "spec_helper"
 require "chef-acceptance/cli"
 
 context "generate command" do
-  let(:options)  { [ "generate", "trivial" ] }
+  let(:options) { [ "generate", "trivial" ] }
 
   it "generates a cookbook" do
     Dir.mktmpdir do |dir|

--- a/spec/integration/cli_spec.rb
+++ b/spec/integration/cli_spec.rb
@@ -36,7 +36,6 @@ context "ChefAcceptance::Cli" do
     end
   end
 
-
   context "for a valid test suite" do
     %w{ provision verify destroy }.each do |command|
       context "with #{command} command" do
@@ -76,7 +75,6 @@ context "ChefAcceptance::Cli" do
       end
     end
   end
-
 
   context "for a failing verify phase in the suite" do
     context "with verify command" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -31,7 +31,7 @@ def ensure_project_root
 end
 
 def acceptance_log_prefix_regex
-  /CHEF-ACCEPTANCE::INFO::\[[\d\-\s:]+\]/
+  /CHEF-ACCEPTANCE::INFO::\[[\d\-\s:+]+\]/
 end
 
 def duration_regex

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -29,3 +29,21 @@ ACCEPTANCE_TEST_DIRECTORY = File.join(PROJECT_ROOT, "test/fixtures/cookbooks/acc
 def ensure_project_root
   Dir.chdir(PROJECT_ROOT)
 end
+
+def acceptance_log_prefix_regex
+  /CHEF-ACCEPTANCE::INFO::\[[\d\-\s:]+\]/
+end
+
+def duration_regex
+  /\d{2}:\d{2}:\d{2}/
+end
+
+def acceptance_table_regex(suite_name, phase, error)
+  /#{acceptance_log_prefix_regex}.+#{suite_name}.+#{phase}.+#{duration_regex}.+#{error ? "Y" : "N"}.+/
+end
+
+def expect_in_acceptance_logs(suite_name, phase, error, *logs)
+  logs.each do |log|
+    expect(log).to match(acceptance_table_regex(suite_name, phase, error))
+  end
+end

--- a/spec/unit/logger_spec.rb
+++ b/spec/unit/logger_spec.rb
@@ -1,0 +1,45 @@
+require "spec_helper"
+require "chef-acceptance/logger"
+
+describe ChefAcceptance::Logger do
+  let(:temp_dir) { Dir.mktmpdir }
+  let(:log_dir) { File.join(temp_dir, ".acceptance_logs") }
+  let(:log_file) { File.join(log_dir, "acceptance.log") }
+
+  let(:logger) { ChefAcceptance::Logger.new(temp_dir) }
+
+  before do
+    FileUtils.rm_rf(File.join(temp_dir, "*"))
+  end
+
+  after do
+    FileUtils.rm_rf(temp_dir)
+  end
+
+  def log_format(message)
+    /CHEF-ACCEPTANCE::INFO::\[[\d\-\s:]+\] #{message}/
+  end
+
+  describe "#log" do
+    it "logs correctly" do
+      logger.log("test-log")
+
+      expect(File.read(log_file)).to match(log_format("Initialized acceptance logger..."))
+      expect(File.read(log_file)).to match(log_format("test-log"))
+    end
+
+    it "overwrites content in an existing file" do
+      FileUtils.mkdir_p(log_dir)
+      File.open(log_file, File::RDWR | File::CREAT) do |f|
+        f.write("Some existing content")
+      end
+      expect(File.read(log_file)).to match("Some existing content")
+
+      logger.log("test-log")
+      expect(File.read(log_file)).not_to match("Some existing content")
+      expect(File.read(log_file)).to match(log_format("Initialized acceptance logger..."))
+      expect(File.read(log_file)).to match(log_format("test-log"))
+    end
+  end
+
+end

--- a/spec/unit/logger_spec.rb
+++ b/spec/unit/logger_spec.rb
@@ -17,7 +17,7 @@ describe ChefAcceptance::Logger do
   end
 
   def log_format(message)
-    /CHEF-ACCEPTANCE::INFO::\[[\d\-\s:]+\] #{message}/
+    /#{acceptance_log_prefix_regex} #{message}/
   end
 
   describe "#log" do

--- a/spec/unit/output_formatter_spec.rb
+++ b/spec/unit/output_formatter_spec.rb
@@ -5,7 +5,7 @@ describe ChefAcceptance::OutputFormatter do
   let(:formatter) { ChefAcceptance::OutputFormatter.new }
   let(:test_rows) {
     unformatted_rows.map do |row|
-      row = {suite: row[0], command: row[1], duration: row[2], error: row[3]}
+      row = { suite: row[0], command: row[1], duration: row[2], error: row[3] }
     end
   }
 


### PR DESCRIPTION
\cc @patrick-wright @sersut 

This is the first part for https://chefio.atlassian.net/browse/ECO-273. This add the ability to log $things into the top level `acceptance.log`. As a follow up we'll implement `add_suite_logger` in `Logger` to create one log per suite.