### PR TITLE
Install chef-client for specs

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,35 +1,6 @@
 AllCops:
-  Include:
-    - Berksfile
-    - Gemfile
-    - Rakefile
-    - Thorfile
-    - Guardfile
-    - Policyfile.rb
   Exclude:
-    - vendor/**/*
-    - chef-zero-local/**/*
-
-AlignParameters:
-  Enabled: false
-Documentation:
-  Enabled: false
-Encoding:
-  Enabled: false
-ClassLength:
-  Enabled: false
-MethodLength:
-  Enabled: false
-Metrics/AbcSize:
-  Enabled: false
-LineLength:
-  Enabled: false
-PerceivedComplexity:
-  Enabled: false
-Style/FileName:
-  Enabled: false
-Style/GuardClause:
-  Enabled: false
-Style/SingleSpaceBeforeFirstArg:
-  Exclude:
-    - '**/metadata.rb'
+    - "spec/data/**/*"
+    - "vendor/**/*"
+    - "pkg/**/*"
+    - "chef-config/pkg/**/*"

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,10 @@ addons:
     packages:
       - chef
 
+branches:
+  only:
+  - master
+
 language: ruby
 sudo: false
 rvm:

--- a/chef-acceptance.gemspec
+++ b/chef-acceptance.gemspec
@@ -23,4 +23,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'pry'
   s.add_development_dependency 'pry-byebug'
   s.add_development_dependency 'pry-stack_explorer'
+  s.add_development_dependency 'chef'
 end

--- a/chef-acceptance.gemspec
+++ b/chef-acceptance.gemspec
@@ -1,27 +1,27 @@
-$LOAD_PATH << File.join(File.dirname(__FILE__), 'lib')
-require 'chef-acceptance/version'
+$LOAD_PATH << File.join(File.dirname(__FILE__), "lib")
+require "chef-acceptance/version"
 
 Gem::Specification.new do |s|
-  s.name          = 'chef-acceptance'
+  s.name          = "chef-acceptance"
   s.version       = ChefAcceptance::VERSION
-  s.summary       = 'Chef Acceptance Framework'
-  s.description   = 'Framework for executing embedded Chef acceptance tests'
-  s.homepage      = 'http://github.com/chef/chef-acceptance'
-  s.authors       = ['Patrick Wright']
-  s.email         = 'patrick@chef.io'
+  s.summary       = "Chef Acceptance Framework"
+  s.description   = "Framework for executing embedded Chef acceptance tests"
+  s.homepage      = "http://github.com/chef/chef-acceptance"
+  s.authors       = ["Patrick Wright"]
+  s.email         = "patrick@chef.io"
   s.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec)/}) }
-  s.require_paths = ['lib']
-  s.bindir        = 'bin'
+  s.require_paths = ["lib"]
+  s.bindir        = "bin"
   s.executables   = %w{ chef-acceptance }
 
-  s.add_dependency 'thor', '~> 0.19'
+  s.add_dependency "thor", "~> 0.19"
   s.add_dependency "mixlib-shellout", "~> 2.0"
 
-  s.add_development_dependency 'rake'
-  s.add_development_dependency 'rspec'
-  s.add_development_dependency 'gem-release'
-  s.add_development_dependency 'pry'
-  s.add_development_dependency 'pry-byebug'
-  s.add_development_dependency 'pry-stack_explorer'
-  s.add_development_dependency 'chef'
+  s.add_development_dependency "rake"
+  s.add_development_dependency "rspec"
+  s.add_development_dependency "gem-release"
+  s.add_development_dependency "pry"
+  s.add_development_dependency "pry-byebug"
+  s.add_development_dependency "pry-stack_explorer"
+  s.add_development_dependency "chef"
 end

--- a/lib/chef-acceptance/application.rb
+++ b/lib/chef-acceptance/application.rb
@@ -21,7 +21,7 @@ module ChefAcceptance
       @errors = {}
       @logger = ChefAcceptance::Logger.new(
         log_header: "CHEF-ACCEPTANCE",
-        log_path: File.join(".acceptance_logs", "acceptance.log"),
+        log_path: File.join(".acceptance_logs", "acceptance.log")
       )
     end
 

--- a/lib/chef-acceptance/chef_runner.rb
+++ b/lib/chef-acceptance/chef_runner.rb
@@ -29,7 +29,7 @@ module ChefAcceptance
         cwd: acceptance_cookbook.root_dir,
         chef_config_file: chef_config_file,
         dna_json_file: dna_json_file,
-        recipe: recipe,
+        recipe: recipe
       )
 
       Bundler.with_clean_env do
@@ -46,8 +46,8 @@ module ChefAcceptance
     def dna
       {
         "chef-acceptance" => {
-          "suite-dir" => File.expand_path(test_suite.name)
-        }
+          "suite-dir" => File.expand_path(test_suite.name),
+        },
       }
     end
 
@@ -90,7 +90,7 @@ module ChefAcceptance
 
       suite_logger = ChefAcceptance::Logger.new(
         log_header: "#{test_suite.name.upcase}::#{recipe.upcase}",
-        log_path: File.join(".acceptance_logs", test_suite.name, "#{recipe}.log"),
+        log_path: File.join(".acceptance_logs", test_suite.name, "#{recipe}.log")
       )
       Mixlib::ShellOut.new(shellout.join(" "), cwd: cwd, live_stream: suite_logger, timeout: 3600)
     end

--- a/spec/unit/logger_spec.rb
+++ b/spec/unit/logger_spec.rb
@@ -10,7 +10,7 @@ describe ChefAcceptance::Logger do
     ChefAcceptance::Logger.new(
       base_dir: temp_dir,
       log_header: "CHEF-ACCEPTANCE",
-      log_path: File.join(".acceptance_logs", "acceptance.log"),
+      log_path: File.join(".acceptance_logs", "acceptance.log")
     )
   end
 

--- a/spec/unit/output_formatter_spec.rb
+++ b/spec/unit/output_formatter_spec.rb
@@ -23,7 +23,7 @@ describe ChefAcceptance::OutputFormatter do
   context "when there is a single row" do
     let(:unformatted_rows) {
       [
-        ["suite2", "destroy", 10000000000, false]
+        ["suite2", "destroy", 10000000000, false],
       ]
     }
 


### PR DESCRIPTION
I just installed a new Ruby, which didn't have a chef gem. In this state, the specs did not pass.