### PR TITLE
Enabling audit mode so acceptance recipes can use control_groups

### DIFF
--- a/lib/chef-acceptance/chef_runner.rb
+++ b/lib/chef-acceptance/chef_runner.rb
@@ -62,6 +62,7 @@ module ChefAcceptance
         ]
         node_path #{File.expand_path('nodes', acceptance_cookbook.root_dir).inspect}
         stream_execute_output true
+        audit_mode :enabled
       EOS
     end
 


### PR DESCRIPTION
\cc @sersut @patrick-wright 