### PR TITLE
Groundwork for supporting configurable options

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ Gemfile.lock
 .kitchen.local.yml
 
 pkg/
+.acceptance_logs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Test results summary displayed at end of run
 - Multiple test suite can be run by using a regex
 - Not specifying any suites will run all available suites
+- `--timeout=N` option to configure timeout for chef-client
+- `--audit-mode` and `--no-audit-mode` options set audit_mode in the config.rb to :enabled or :disabled, respectively.
 
 
 ### Fixed

--- a/lib/chef-acceptance/options.rb
+++ b/lib/chef-acceptance/options.rb
@@ -1,0 +1,15 @@
+module ChefAcceptance
+  class Options
+    attr_reader :timeout
+    attr_reader :force_destroy
+    attr_reader :audit_mode
+
+    DEFAULT_TIMEOUT = 7200
+
+    def initialize(options = {})
+      @timeout = options.fetch("timeout", DEFAULT_TIMEOUT)
+      @force_destroy = options.fetch("force_destroy", false)
+      @audit_mode = options.fetch("audit_mode", true)
+    end
+  end
+end

--- a/spec/integration/chef_runner_spec.rb
+++ b/spec/integration/chef_runner_spec.rb
@@ -3,14 +3,21 @@ require "chef-acceptance/chef_runner"
 require "chef-acceptance/test_suite"
 
 context ChefAcceptance::ChefRunner do
+  let(:test_suite) { ChefAcceptance::TestSuite.new("foo") }
+  let(:options) { { "audit_mode" => false } }
+  let(:options_instance) { ChefAcceptance::Options.new(options) }
+  let(:runner) { ChefAcceptance::ChefRunner.new(test_suite, "provision", options_instance) }
+
+  def run
+    capture(:stdout) { runner.run! }
+  end
+
   it "calls run" do
     Dir.mktmpdir do |dir|
       ChefAcceptance::AcceptanceCookbook.new(File.join(dir, "foo", ".acceptance")).generate
       Dir.chdir dir
-      test_suite = ChefAcceptance::TestSuite.new("foo")
-      runner = ChefAcceptance::ChefRunner.new(test_suite, "provision")
 
-      expect(capture(:stdout) { runner.run! }).to match(/Running 'provision' recipe from the acceptance-cookbook in directory '.*foo'/)
+      expect(run).to match(/Running 'provision' recipe from the acceptance-cookbook in directory '.*foo'/)
     end
   end
 
@@ -20,19 +27,30 @@ context ChefAcceptance::ChefRunner do
       # Create an empty testme cookbook in .shared/testme
       Dir.mkdir File.join(dir, ".shared")
       Dir.mkdir File.join(dir, ".shared", "testme")
-      IO.write(File.join(dir, ".shared", "testme", "metadata.rb"), <<-EOM)
-        name "testme"
-      EOM
+      IO.write(File.join(dir, ".shared", "testme", "metadata.rb"), <<-EOM
+          name "testme"
+        EOM
+      )
       # Depend on the testme cookbook in the acceptance-cookbook
       IO.write(File.join(dir, "foo", ".acceptance", "acceptance-cookbook", "metadata.rb"), <<-EOM)
         name "acceptance-cookbook"
         depends "testme"
       EOM
       Dir.chdir dir
-      test_suite = ChefAcceptance::TestSuite.new("foo")
-      runner = ChefAcceptance::ChefRunner.new(test_suite, "provision")
 
-      expect(capture(:stdout) { runner.run! }).to match(/Running 'provision' recipe from the acceptance-cookbook in directory '.*foo'/)
+      expect(run).to match(/Running 'provision' recipe from the acceptance-cookbook in directory '.*foo'/)
+    end
+  end
+
+  context "with a ridiculously short timeout setting" do
+    let(:options) { { "timeout" => 1 } }
+
+    it "times out" do
+      Dir.mktmpdir do |dir|
+        ChefAcceptance::AcceptanceCookbook.new(File.join(dir, "foo", ".acceptance")).generate
+        Dir.chdir dir
+        expect { runner.run! }.to raise_error(Mixlib::ShellOut::CommandTimeout)
+      end
     end
   end
 end

--- a/spec/integration/cli_spec.rb
+++ b/spec/integration/cli_spec.rb
@@ -178,4 +178,14 @@ context "ChefAcceptance::Cli" do
       expect_in_acceptance_logs("test-suite", "destroy", false, stdout, acceptance_log)
     end
   end
+
+  context "--no-audit-mode" do
+    let(:options) { %w{test test-suite --no-audit-mode} }
+
+    it "sets audit_mode to disabled" do
+      stdout = run_acceptance
+      config_rb = File.join(ACCEPTANCE_TEST_DIRECTORY, "test-suite", ".acceptance", "acceptance-cookbook", "tmp", ".chef", "config.rb")
+      expect(File.read(config_rb)).to match "audit_mode :disabled"
+    end
+  end
 end

--- a/spec/unit/application_spec.rb
+++ b/spec/unit/application_spec.rb
@@ -35,7 +35,15 @@ describe ChefAcceptance::Application do
 
   context "options" do
     it "force-destroy by default should be false" do
-      expect(app.force_destroy).to be false
+      expect(app.options.force_destroy).to be false
+    end
+
+    it "timeout by default" do
+      expect(app.options.timeout).to eq 7200
+    end
+
+    it "audit_mode by default" do
+      expect(app.options.audit_mode).to be true
     end
 
     context "force-destroy: true" do
@@ -44,7 +52,27 @@ describe ChefAcceptance::Application do
       end
 
       it "should be settable" do
-        expect(app.force_destroy).to be true
+        expect(app.options.force_destroy).to be true
+      end
+    end
+
+    context "set timeout" do
+      let(:app_options) do
+        { "timeout" => 10000 }
+      end
+
+      it "should be settable" do
+        expect(app.options.timeout).to eq 10000
+      end
+    end
+
+    context "set audit_mode" do
+      let(:app_options) do
+        { "audit_mode" => false }
+      end
+
+      it "should be settable" do
+        expect(app.options.audit_mode).to eq false
       end
     end
   end
@@ -99,7 +127,7 @@ describe ChefAcceptance::Application do
             allow(runner).to receive(:duration).and_return(10)
 
             expect(ChefAcceptance::ChefRunner).to receive(:new)
-              .with(kind_of(ChefAcceptance::TestSuite), c).and_return(runner)
+              .with(kind_of(ChefAcceptance::TestSuite), c, kind_of(ChefAcceptance::Options)).and_return(runner)
           end
 
           it "should output correctly" do
@@ -136,7 +164,7 @@ describe ChefAcceptance::Application do
 
           expected_commands.each do |c|
             expect(ChefAcceptance::ChefRunner).to receive(:new).ordered
-              .with(kind_of(ChefAcceptance::TestSuite), c).and_return(runner)
+              .with(kind_of(ChefAcceptance::TestSuite), c, kind_of(ChefAcceptance::Options)).and_return(runner)
           end
         end
 

--- a/spec/unit/chef_runner_spec.rb
+++ b/spec/unit/chef_runner_spec.rb
@@ -2,13 +2,15 @@ require "spec_helper"
 require "chef-acceptance/chef_runner"
 require "chef-acceptance/test_suite"
 require "chef-acceptance/acceptance_cookbook"
+require "chef-acceptance/options"
 
 describe ChefAcceptance::ChefRunner do
   let(:acceptance_cookbook) { instance_double(ChefAcceptance::AcceptanceCookbook, root_dir: root_dir) }
   let(:test_suite) { instance_double(ChefAcceptance::TestSuite, name: "some_suite", acceptance_cookbook: acceptance_cookbook) }
   let(:recipe) { "provision" }
   let(:root_dir) { "/tmp" }
-  let(:ccr) { ChefAcceptance::ChefRunner.new(test_suite, recipe) }
+  let(:options) { ChefAcceptance::Options.new }
+  let(:ccr) { ChefAcceptance::ChefRunner.new(test_suite, recipe, options) }
   let(:ccr_shellout) { instance_double(Mixlib::ShellOut) }
 
   it "initializes" do


### PR DESCRIPTION
Add configurable options.
`--timeout 10000` defaults to 7200
`--no-audit-mode` sets audit_mode in config.rb to `:disabled`.  Set to `:enabled` by default.

@tyler-ball @chefsalim @sersut 