### PR TITLE
Create temporary files required for chef run under platform tmpdir.

### DIFF
--- a/lib/chef-acceptance/chef_runner.rb
+++ b/lib/chef-acceptance/chef_runner.rb
@@ -4,6 +4,7 @@ require "json"
 require "bundler"
 require "chef-acceptance/acceptance_cookbook"
 require "chef-acceptance/logger"
+require "tmpdir"
 
 module ChefAcceptance
 
@@ -60,7 +61,7 @@ module ChefAcceptance
           #{File.expand_path('..', acceptance_cookbook.root_dir).inspect},
           #{File.expand_path('../../../.shared', acceptance_cookbook.root_dir).inspect}
         ]
-        node_path #{File.expand_path('nodes', acceptance_cookbook.root_dir).inspect}
+        node_path #{File.expand_path('nodes', temp_dir).inspect}
         stream_execute_output true
         audit_mode :enabled
       EOS
@@ -97,7 +98,7 @@ module ChefAcceptance
     end
 
     def temp_dir
-      File.join(acceptance_cookbook.root_dir, "tmp")
+      File.join(Dir.tmpdir, "chef-acceptance", test_suite.name)
     end
 
     def chef_dir

--- a/spec/unit/chef_runner_spec.rb
+++ b/spec/unit/chef_runner_spec.rb
@@ -25,18 +25,19 @@ describe ChefAcceptance::ChefRunner do
 
     it "successfully runs the shellout" do
       # step into prepare_required_files
-      expect(FileUtils).to receive(:rmtree).with("#{root_dir}/tmp")
-      expect(FileUtils).to receive(:mkpath).with("#{root_dir}/tmp")
-      expect(File).to receive(:write).with("#{root_dir}/tmp/dna.json", /suite-dir/)
-      expect(FileUtils).to receive(:mkpath).with("#{root_dir}/tmp/.chef")
-      expect(File).to receive(:write).with("#{root_dir}/tmp/.chef/config.rb", /cookbook_path/)
+      tmp_dir = File.join(Dir.tmpdir, "chef-acceptance", "some_suite")
+      expect(FileUtils).to receive(:rmtree).with(tmp_dir)
+      expect(FileUtils).to receive(:mkpath).with(tmp_dir)
+      expect(File).to receive(:write).with("#{tmp_dir}/dna.json", /suite-dir/)
+      expect(FileUtils).to receive(:mkpath).with("#{tmp_dir}/.chef")
+      expect(File).to receive(:write).with("#{tmp_dir}/.chef/config.rb", /cookbook_path/)
 
       expect(Mixlib::ShellOut).to receive(:new).with(
         [
           "chef-client -z",
-          "-c /tmp/tmp/.chef/config.rb",
+          "-c #{tmp_dir}/.chef/config.rb",
           "--force-formatter",
-          "-j /tmp/tmp/dna.json",
+          "-j #{tmp_dir}/dna.json",
           "-o acceptance-cookbook::provision",
           "--no-color",
         ].join(" "), cwd: root_dir, live_stream: instance_of(ChefAcceptance::Logger), timeout: 7200


### PR DESCRIPTION
Fixes https://github.com/chef/chef-acceptance/issues/36.

/cc: @chef/engineering-services 