### PR TITLE
Add --log-dir CLI option

### DIFF
--- a/chef-acceptance.gemspec
+++ b/chef-acceptance.gemspec
@@ -24,4 +24,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency "pry-byebug"
   s.add_development_dependency "pry-stack_explorer"
   s.add_development_dependency "chef"
+  s.add_development_dependency "rb-readline"
 end

--- a/lib/chef-acceptance/application.rb
+++ b/lib/chef-acceptance/application.rb
@@ -16,17 +16,19 @@ module ChefAcceptance
     WORKER_POOL_SIZE = 3
 
     attr_reader :force_destroy
+    attr_reader :log_dir
     attr_reader :output_formatter
     attr_reader :errors
     attr_reader :logger
 
     def initialize(options = {})
       @force_destroy = options.fetch("force_destroy", false)
+      @log_dir = options.fetch("log_dir", File.join(Dir.pwd, ".acceptance_logs"))
       @output_formatter = OutputFormatter.new
       @errors = {}
       @logger = ChefAcceptance::Logger.new(
         log_header: "CHEF-ACCEPTANCE",
-        log_path: File.join(".acceptance_logs", "acceptance.log")
+        log_path: File.join(log_dir, "acceptance.log")
       )
       @error_mutex = Mutex.new
     end
@@ -138,7 +140,7 @@ module ChefAcceptance
 
     def run_command(test_suite, command)
       recipe = command == "force-destroy" ? "destroy" : command
-      runner = ChefRunner.new(test_suite, recipe)
+      runner = ChefRunner.new(test_suite, recipe, log_dir: log_dir)
       error = false
       begin
         runner.run!

--- a/lib/chef-acceptance/chef_runner.rb
+++ b/lib/chef-acceptance/chef_runner.rb
@@ -4,6 +4,7 @@ require "json"
 require "bundler"
 require "chef-acceptance/acceptance_cookbook"
 require "chef-acceptance/logger"
+require "tmpdir"
 
 module ChefAcceptance
 
@@ -60,7 +61,7 @@ module ChefAcceptance
           #{File.expand_path('..', acceptance_cookbook.root_dir).inspect},
           #{File.expand_path('../../../.shared', acceptance_cookbook.root_dir).inspect}
         ]
-        node_path #{File.expand_path('nodes', acceptance_cookbook.root_dir).inspect}
+        node_path #{File.expand_path('nodes', temp_dir).inspect}
         stream_execute_output true
         audit_mode :enabled
       EOS
@@ -97,7 +98,7 @@ module ChefAcceptance
     end
 
     def temp_dir
-      File.join(acceptance_cookbook.root_dir, "tmp")
+      File.join(Dir.tmpdir, "chef-acceptance", test_suite.name)
     end
 
     def chef_dir

--- a/lib/chef-acceptance/chef_runner.rb
+++ b/lib/chef-acceptance/chef_runner.rb
@@ -14,12 +14,14 @@ module ChefAcceptance
     attr_reader :test_suite
     attr_reader :recipe
     attr_reader :duration
+    attr_reader :log_dir
 
-    def initialize(test_suite, recipe)
+    def initialize(test_suite, recipe, log_dir: File.join(Dir.pwd, ".acceptance_logs"))
       @test_suite = test_suite
       @acceptance_cookbook = test_suite.acceptance_cookbook
       @recipe = recipe
       @duration = 0
+      @log_dir = log_dir
     end
 
     def run!
@@ -92,7 +94,7 @@ module ChefAcceptance
 
       suite_logger = ChefAcceptance::Logger.new(
         log_header: "#{test_suite.name.upcase}::#{recipe.upcase}",
-        log_path: File.join(".acceptance_logs", test_suite.name, "#{recipe}.log")
+        log_path: File.join(log_dir, test_suite.name, "#{recipe}.log")
       )
       Mixlib::ShellOut.new(shellout.join(" "), cwd: cwd, live_stream: suite_logger, timeout: 7200)
     end

--- a/lib/chef-acceptance/cli.rb
+++ b/lib/chef-acceptance/cli.rb
@@ -13,17 +13,23 @@ module ChefAcceptance
     # Create core acceptance commands
     #
     AcceptanceCookbook::CORE_ACCEPTANCE_RECIPES.each do |command|
-      desc "#{command} TEST_SUITE_REGEX", "Run #{command}"
+      desc "#{command} TEST_SUITE_REGEX [--log-dir=/log/directory]", "Run #{command}"
+      option :log_dir,
+        type: :string,
+        desc: "Directory to create log files under"
       define_method(command) do |test_suite_regex = ".*"|
-        app = Application.new()
+        app = Application.new(options)
         app.run(test_suite_regex, command)
       end
     end
 
-    desc "test TEST_SUITE_REGEX [--force-destroy]", "Run provision, verify and destroy"
+    desc "test TEST_SUITE_REGEX [--force-destroy] [--log-dir=/log/directory]", "Run provision, verify and destroy"
+    option :log_dir,
+      type: :string,
+      desc: "Directory to create log files under"
     option :force_destroy,
-           type: :boolean,
-           desc: "Force destroy phase after any run"
+      type: :boolean,
+      desc: "Force destroy phase after any run"
     def test(test_suite_regex = ".*")
       app = Application.new(options)
       app.run(test_suite_regex, "test")

--- a/lib/chef-acceptance/logger.rb
+++ b/lib/chef-acceptance/logger.rb
@@ -8,19 +8,14 @@ module ChefAcceptance
     attr_reader :stdout_logger
 
     # Supported options:
-    # base_dir: Base directory for the logs. Primarily used by specs. We
-    #   default to current working directory.
     # log_path: relative path of the log file; relative to the given base_dir.
     # log_header: the prefix logger will print when logging messages.
     def initialize(options = {})
       @log_header = options.fetch(:log_header)
-
-      base_dir = options.fetch(:base_dir, Dir.pwd)
-      @log_path = File.join(base_dir, options.fetch(:log_path))
-      log_directory = File.dirname(log_path)
+      @log_path = options.fetch(:log_path)
 
       # create the main logs directory
-      FileUtils.mkdir_p(log_directory)
+      FileUtils.mkdir_p(File.dirname(log_path))
 
       @file_logger = create_file_logger
       @stdout_logger = create_stdout_logger
@@ -61,9 +56,5 @@ module ChefAcceptance
       logger
     end
 
-    # def add_suite_logger(suite_name)
-    #   FileUtils.mkdir_p(File.join(log_directory, suite_name))
-    #   # create our suite_logger
-    # end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,7 +2,6 @@ $LOAD_PATH << File.join(File.dirname(__FILE__), "../lib")
 
 RSpec.configure do |conf|
   conf.filter_run focus: true
-  conf.filter_run_excluding vagrant: true
   conf.run_all_when_everything_filtered = true
 
   conf.expect_with :rspec do |c|

--- a/spec/unit/application_spec.rb
+++ b/spec/unit/application_spec.rb
@@ -99,7 +99,7 @@ describe ChefAcceptance::Application do
             allow(runner).to receive(:duration).and_return(10)
 
             expect(ChefAcceptance::ChefRunner).to receive(:new)
-              .with(kind_of(ChefAcceptance::TestSuite), c).and_return(runner)
+              .with(kind_of(ChefAcceptance::TestSuite), c, log_dir: kind_of(String)).and_return(runner)
           end
 
           it "should output correctly" do
@@ -136,7 +136,7 @@ describe ChefAcceptance::Application do
 
           expected_commands.each do |c|
             expect(ChefAcceptance::ChefRunner).to receive(:new).ordered
-              .with(kind_of(ChefAcceptance::TestSuite), c).and_return(runner)
+              .with(kind_of(ChefAcceptance::TestSuite), c, log_dir: kind_of(String)).and_return(runner)
           end
         end
 

--- a/spec/unit/chef_runner_spec.rb
+++ b/spec/unit/chef_runner_spec.rb
@@ -25,18 +25,19 @@ describe ChefAcceptance::ChefRunner do
 
     it "successfully runs the shellout" do
       # step into prepare_required_files
-      expect(FileUtils).to receive(:rmtree).with("#{root_dir}/tmp")
-      expect(FileUtils).to receive(:mkpath).with("#{root_dir}/tmp")
-      expect(File).to receive(:write).with("#{root_dir}/tmp/dna.json", /suite-dir/)
-      expect(FileUtils).to receive(:mkpath).with("#{root_dir}/tmp/.chef")
-      expect(File).to receive(:write).with("#{root_dir}/tmp/.chef/config.rb", /cookbook_path/)
+      tmp_dir = File.join(Dir.tmpdir, "chef-acceptance", "some_suite")
+      expect(FileUtils).to receive(:rmtree).with(tmp_dir)
+      expect(FileUtils).to receive(:mkpath).with(tmp_dir)
+      expect(File).to receive(:write).with("#{tmp_dir}/dna.json", /suite-dir/)
+      expect(FileUtils).to receive(:mkpath).with("#{tmp_dir}/.chef")
+      expect(File).to receive(:write).with("#{tmp_dir}/.chef/config.rb", /cookbook_path/)
 
       expect(Mixlib::ShellOut).to receive(:new).with(
         [
           "chef-client -z",
-          "-c /tmp/tmp/.chef/config.rb",
+          "-c #{tmp_dir}/.chef/config.rb",
           "--force-formatter",
-          "-j /tmp/tmp/dna.json",
+          "-j #{tmp_dir}/dna.json",
           "-o acceptance-cookbook::provision",
           "--no-color",
         ].join(" "), cwd: root_dir, live_stream: instance_of(ChefAcceptance::Logger), timeout: 7200

--- a/spec/unit/logger_spec.rb
+++ b/spec/unit/logger_spec.rb
@@ -3,14 +3,12 @@ require "chef-acceptance/logger"
 
 describe ChefAcceptance::Logger do
   let(:temp_dir) { Dir.mktmpdir }
-  let(:log_dir) { File.join(temp_dir, ".acceptance_logs") }
-  let(:log_file) { File.join(log_dir, "acceptance.log") }
+  let(:log_file) { File.join(temp_dir, ".acceptance_logs", "acceptance.log") }
 
   let(:logger) do
     ChefAcceptance::Logger.new(
-      base_dir: temp_dir,
       log_header: "CHEF-ACCEPTANCE",
-      log_path: File.join(".acceptance_logs", "acceptance.log")
+      log_path: log_file
     )
   end
 
@@ -30,12 +28,12 @@ describe ChefAcceptance::Logger do
     it "logs correctly" do
       logger.log("test-log")
 
-      expect(File.read(log_file)).to match(log_format(/Initialized \[.acceptance_logs\/acceptance.log\] logger.../))
+      expect(File.read(log_file)).to match(log_format(/Initialized \[(.*).acceptance_logs\/acceptance.log\] logger.../))
       expect(File.read(log_file)).to match(log_format("test-log"))
     end
 
     it "overwrites content in an existing file" do
-      FileUtils.mkdir_p(log_dir)
+      FileUtils.mkdir_p(File.dirname(log_file))
       File.open(log_file, File::RDWR | File::CREAT) do |f|
         f.write("Some existing content")
       end
@@ -43,7 +41,7 @@ describe ChefAcceptance::Logger do
 
       logger.log("test-log")
       expect(File.read(log_file)).not_to match("Some existing content")
-      expect(File.read(log_file)).to match(log_format(/Initialized \[.acceptance_logs\/acceptance.log\] logger.../))
+      expect(File.read(log_file)).to match(log_format(/Initialized \[(.*).acceptance_logs\/acceptance.log\] logger.../))
       expect(File.read(log_file)).to match(log_format("test-log"))
     end
   end


### PR DESCRIPTION
This PR does two things:

1. Relocates the temporary files required for chef runs under system tmpdir.
2. Adds a `--log-dir` CLI option to the testing related subcommands.

/cc: @schisamo @patrick-wright 