### PR TITLE
--data-path option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,4 +15,4 @@ Gemfile.lock
 .kitchen.local.yml
 
 pkg/
-.acceptance_logs
+.acceptance_data

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,41 +1,25 @@
-# Change Log
-This change log follows the principles
-outlined from [Keep a CHANGELOG](http://keepachangelog.com/).
+# CHANGELOG
 
-All notable changes to this project will be documented in this file.
-This project adheres to [Semantic Versioning](http://semver.org/).
+We strongly recommend following `master` branch for chef-acceptance.
 
-## [Unreleased]
-### Added
+## [master]
+- `--data-path` option to core commands which can be used to override the directory in which temporary chef files and log files will be created.
+- `--timeout=N` option to configure timeout for chef-client
+- `--audit-mode` and `--no-audit-mode` options set audit_mode in the config.rb to :enabled or :disabled, respectively.
 - `node['chef-acceptance']['suite-dir']` attribute available in acceptance cookbook recipes
 - Exit code is set properly based on test failures.
 - Test results summary displayed at end of run
 - Multiple test suite can be run by using a regex
 - Not specifying any suites will run all available suites
-- `--timeout=N` option to configure timeout for chef-client
-- `--audit-mode` and `--no-audit-mode` options set audit_mode in the config.rb to :enabled or :disabled, respectively.
-
-
-### Fixed
-- `test` command returns non-zero exit code when an error is encountered
 - Run Chef under a clean bundler environment.
-
-### Changed
-- `config.rb` is generated automatically
 - Improved error handling when running test suites
 
-## [0.2.0] - 2015-11-17
-### Changed
+## [0.2.0]
 - `test` command `--destroy` option changed to a boolean as `--skip-destroy`
 - Relax all development dependency versions
 
-## [0.1.0] - 2015-10-28
-### Added
+## [0.1.0]
 - `chef-acceptance` executable
 - `provision`, `verify`, `destroy`, `test`, `generate` commands
 - utility commands
 - Travis CI support
-
-[Unreleased]: https://github.com/chef/chef-acceptance/compare/v0.2.0...HEAD
-[0.2.0]: https://github.com/chef/chef-acceptance/compare/v0.1.0...v0.2.0
-[0.1.0]: https://github.com/chef/chef-acceptance/compare/3b46b84532f734f07b2cca5e4c57d34ec535f0d7...v0.1.0

--- a/README.md
+++ b/README.md
@@ -53,6 +53,9 @@ chef-acceptance test my-test-suite
 
 ## Commands
 
+For available options of commands run:
+`chef-acceptance help <command-name>`
+
 `chef-acceptance provision <suite-regex>`
 Runs the provision recipe for the matching acceptance suites.
 
@@ -87,8 +90,7 @@ end
 
 ## Change Log
 
-The [change log](CHANGELOG.md) for this project follows the principles outlined
-from [Keep a CHANGELOG](http://keepachangelog.com/).
+See [CHANGELOG.md](CHANGELOG.md).
 
 ## Releasing chef-acceptance
 

--- a/chef-acceptance.gemspec
+++ b/chef-acceptance.gemspec
@@ -23,5 +23,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency "pry"
   s.add_development_dependency "pry-byebug"
   s.add_development_dependency "pry-stack_explorer"
+  s.add_development_dependency "rb-readline"
   s.add_development_dependency "chef"
 end

--- a/lib/chef-acceptance/application.rb
+++ b/lib/chef-acceptance/application.rb
@@ -21,13 +21,13 @@ module ChefAcceptance
     attr_reader :errors
     attr_reader :logger
 
-    def initialize(options = {})
-      @options = ChefAcceptance::Options.new(options)
+    def initialize(opt = {})
+      @options = ChefAcceptance::Options.new(opt)
       @output_formatter = OutputFormatter.new
       @errors = {}
       @logger = ChefAcceptance::Logger.new(
         log_header: "CHEF-ACCEPTANCE",
-        log_path: File.join(".acceptance_logs", "acceptance.log")
+        log_path: File.join(options.data_path, "logs", "acceptance.log")
       )
       @error_mutex = Mutex.new
     end

--- a/lib/chef-acceptance/chef_runner.rb
+++ b/lib/chef-acceptance/chef_runner.rb
@@ -75,6 +75,7 @@ module ChefAcceptance
           #{File.expand_path('../../../.shared', acceptance_cookbook.root_dir).inspect}
         ]
         node_path "#{node_path}"
+        cache_path "#{cache_path}"
         stream_execute_output true
         audit_mode #{app_options.audit_mode ? ":enabled" : ":disabled"}
       EOS
@@ -118,6 +119,11 @@ module ChefAcceptance
 
     def node_path
       File.join(data_path, "nodes")
+    end
+
+    def cache_path
+      # chef will append "cache" to the configured directory.
+      data_path
     end
 
     def create_file(file_path, file_contents)

--- a/lib/chef-acceptance/cli.rb
+++ b/lib/chef-acceptance/cli.rb
@@ -25,6 +25,12 @@ module ChefAcceptance
       desc: "Enable or disable audit_mode (Default: true)",
     ]
 
+    option_data_path = [
+      :data_path,
+      type: :string,
+      desc: "Override the directory in which temp and log files will be created. (Default: ./.acceptance_data)",
+    ]
+
     #
     # Create core acceptance commands
     #
@@ -32,6 +38,7 @@ module ChefAcceptance
       desc "#{command} TEST_SUITE_REGEX", "Run #{command}"
       option(*option_timeout)
       option(*option_audit_mode)
+      option(*option_data_path)
       define_method(command) do |test_suite_regex = ".*"|
         app = Application.new(options)
         app.run(test_suite_regex, command)
@@ -44,6 +51,7 @@ module ChefAcceptance
            desc: "Force destroy phase after any run"
     option(*option_timeout)
     option(*option_audit_mode)
+    option(*option_data_path)
     def test(test_suite_regex = ".*")
       app = Application.new(options)
       app.run(test_suite_regex, "test")

--- a/lib/chef-acceptance/logger.rb
+++ b/lib/chef-acceptance/logger.rb
@@ -8,19 +8,14 @@ module ChefAcceptance
     attr_reader :stdout_logger
 
     # Supported options:
-    # base_dir: Base directory for the logs. Primarily used by specs. We
-    #   default to current working directory.
-    # log_path: relative path of the log file; relative to the given base_dir.
+    # log_path: full path to the log file
     # log_header: the prefix logger will print when logging messages.
     def initialize(options = {})
       @log_header = options.fetch(:log_header)
-
-      base_dir = options.fetch(:base_dir, Dir.pwd)
-      @log_path = File.join(base_dir, options.fetch(:log_path))
-      log_directory = File.dirname(log_path)
+      @log_path = options.fetch(:log_path)
 
       # create the main logs directory
-      FileUtils.mkdir_p(log_directory)
+      FileUtils.mkdir_p(File.dirname(log_path))
 
       @file_logger = create_file_logger
       @stdout_logger = create_stdout_logger
@@ -61,9 +56,5 @@ module ChefAcceptance
       logger
     end
 
-    # def add_suite_logger(suite_name)
-    #   FileUtils.mkdir_p(File.join(log_directory, suite_name))
-    #   # create our suite_logger
-    # end
   end
 end

--- a/lib/chef-acceptance/options.rb
+++ b/lib/chef-acceptance/options.rb
@@ -3,6 +3,7 @@ module ChefAcceptance
     attr_reader :timeout
     attr_reader :force_destroy
     attr_reader :audit_mode
+    attr_reader :data_path
 
     DEFAULT_TIMEOUT = 7200
 
@@ -10,6 +11,7 @@ module ChefAcceptance
       @timeout = options.fetch("timeout", DEFAULT_TIMEOUT)
       @force_destroy = options.fetch("force_destroy", false)
       @audit_mode = options.fetch("audit_mode", true)
+      @data_path = options.fetch("data_path", File.expand_path(File.join(Dir.pwd, ".acceptance_data")))
     end
   end
 end

--- a/spec/integration/cli_spec.rb
+++ b/spec/integration/cli_spec.rb
@@ -4,21 +4,21 @@ require "chef-acceptance/cli"
 context "ChefAcceptance::Cli" do
   before do
     Dir.chdir(ACCEPTANCE_TEST_DIRECTORY)
-    FileUtils.rm_rf(File.join(ACCEPTANCE_TEST_DIRECTORY, ".acceptance_logs"))
+    FileUtils.rm_rf(acceptance_data_path)
   end
 
   after do
-    FileUtils.rm_rf(File.join(ACCEPTANCE_TEST_DIRECTORY, ".acceptance_logs"))
+    FileUtils.rm_rf(acceptance_data_path)
   end
 
   let(:failure_expected) { false }
-
+  let(:acceptance_data_path) { File.join(ACCEPTANCE_TEST_DIRECTORY, ".acceptance_data") }
   let(:acceptance_log) {
-    File.read(File.join(ACCEPTANCE_TEST_DIRECTORY, ".acceptance_logs", "acceptance.log"))
+    File.read(File.join(acceptance_data_path, "logs", "acceptance.log"))
   }
 
   def suite_log_for(suite_name, command)
-    File.read(File.join(ACCEPTANCE_TEST_DIRECTORY, ".acceptance_logs", suite_name, "#{command}.log"))
+    File.read(File.join(acceptance_data_path, "logs", suite_name, "#{command}.log"))
   end
 
   def run_acceptance
@@ -51,6 +51,18 @@ context "ChefAcceptance::Cli" do
           expect(suite_log_for("test-suite", command)).to match(/the #{command} recipe/)
           expect_in_acceptance_logs("test-suite", command, false, stdout, acceptance_log)
         end
+      end
+    end
+
+    context "with custom data_path and provision command" do
+      let(:acceptance_data_path) { Dir.mktmpdir }
+      let(:options) { [ "provision", "test-suite", "--data-path=#{acceptance_data_path}" ] }
+
+      it "runs successfully" do
+        stdout = run_acceptance
+        expect(stdout).to match(/the provision recipe/)
+        expect(suite_log_for("test-suite", "provision")).to match(/the provision recipe/)
+        expect_in_acceptance_logs("test-suite", "provision", false, stdout, acceptance_log)
       end
     end
 
@@ -184,7 +196,7 @@ context "ChefAcceptance::Cli" do
 
     it "sets audit_mode to disabled" do
       stdout = run_acceptance
-      config_rb = File.join(ACCEPTANCE_TEST_DIRECTORY, "test-suite", ".acceptance", "acceptance-cookbook", "tmp", ".chef", "config.rb")
+      config_rb = File.join(ACCEPTANCE_TEST_DIRECTORY, ".acceptance_data", "chef", "test-suite", "provision", ".chef", "config.rb")
       expect(File.read(config_rb)).to match "audit_mode :disabled"
     end
   end

--- a/spec/unit/application_spec.rb
+++ b/spec/unit/application_spec.rb
@@ -7,7 +7,7 @@ describe ChefAcceptance::Application do
   let(:failure_expected) { false }
   let(:suites) { [] }
   let(:acceptance_log) {
-    File.read(File.join(@acceptance_dir, ".acceptance_logs", "acceptance.log"))
+    File.read(File.join(@acceptance_dir, ".acceptance_data", "logs", "acceptance.log"))
   }
 
   before do
@@ -44,6 +44,10 @@ describe ChefAcceptance::Application do
 
     it "audit_mode by default" do
       expect(app.options.audit_mode).to be true
+    end
+
+    it "data_path by default" do
+      expect(app.options.data_path).to include(".acceptance_data")
     end
 
     context "force-destroy: true" do

--- a/spec/unit/chef_runner_spec.rb
+++ b/spec/unit/chef_runner_spec.rb
@@ -8,7 +8,7 @@ describe ChefAcceptance::ChefRunner do
   let(:acceptance_cookbook) { instance_double(ChefAcceptance::AcceptanceCookbook, root_dir: root_dir) }
   let(:test_suite) { instance_double(ChefAcceptance::TestSuite, name: "some_suite", acceptance_cookbook: acceptance_cookbook) }
   let(:recipe) { "provision" }
-  let(:root_dir) { "/tmp" }
+  let(:root_dir) { options.data_path }
   let(:options) { ChefAcceptance::Options.new }
   let(:ccr) { ChefAcceptance::ChefRunner.new(test_suite, recipe, options) }
   let(:ccr_shellout) { instance_double(Mixlib::ShellOut) }
@@ -27,18 +27,18 @@ describe ChefAcceptance::ChefRunner do
 
     it "successfully runs the shellout" do
       # step into prepare_required_files
-      expect(FileUtils).to receive(:rmtree).with("#{root_dir}/tmp")
-      expect(FileUtils).to receive(:mkpath).with("#{root_dir}/tmp")
-      expect(File).to receive(:write).with("#{root_dir}/tmp/dna.json", /suite-dir/)
-      expect(FileUtils).to receive(:mkpath).with("#{root_dir}/tmp/.chef")
-      expect(File).to receive(:write).with("#{root_dir}/tmp/.chef/config.rb", /cookbook_path/)
+      expect(FileUtils).to receive(:rmtree).with("#{root_dir}/chef/some_suite/provision")
+      expect(FileUtils).to receive(:mkpath).with("#{root_dir}/chef/some_suite/provision").at_least(:once)
+      expect(File).to receive(:write).with("#{root_dir}/chef/some_suite/provision/dna.json", /suite-dir/)
+      expect(FileUtils).to receive(:mkpath).with("#{root_dir}/chef/some_suite/provision/.chef")
+      expect(File).to receive(:write).with("#{root_dir}/chef/some_suite/provision/.chef/config.rb", /cookbook_path/)
 
       expect(Mixlib::ShellOut).to receive(:new).with(
         [
           "chef-client -z",
-          "-c /tmp/tmp/.chef/config.rb",
+          "-c #{root_dir}/chef/some_suite/provision/.chef/config.rb",
           "--force-formatter",
-          "-j /tmp/tmp/dna.json",
+          "-j #{root_dir}/chef/some_suite/provision/dna.json",
           "-o acceptance-cookbook::provision",
           "--no-color",
         ].join(" "), cwd: root_dir, live_stream: instance_of(ChefAcceptance::Logger), timeout: 7200

--- a/spec/unit/logger_spec.rb
+++ b/spec/unit/logger_spec.rb
@@ -3,14 +3,12 @@ require "chef-acceptance/logger"
 
 describe ChefAcceptance::Logger do
   let(:temp_dir) { Dir.mktmpdir }
-  let(:log_dir) { File.join(temp_dir, ".acceptance_logs") }
-  let(:log_file) { File.join(log_dir, "acceptance.log") }
+  let(:log_file) { File.join(Dir.mktmpdir, ".acceptance_data", "logs", "acceptance.log") }
 
   let(:logger) do
     ChefAcceptance::Logger.new(
-      base_dir: temp_dir,
       log_header: "CHEF-ACCEPTANCE",
-      log_path: File.join(".acceptance_logs", "acceptance.log")
+      log_path: log_file
     )
   end
 
@@ -30,12 +28,12 @@ describe ChefAcceptance::Logger do
     it "logs correctly" do
       logger.log("test-log")
 
-      expect(File.read(log_file)).to match(log_format(/Initialized \[.acceptance_logs\/acceptance.log\] logger.../))
+      expect(File.read(log_file)).to match(log_format(/Initialized \[(.*).acceptance_data\/logs\/acceptance.log\] logger.../))
       expect(File.read(log_file)).to match(log_format("test-log"))
     end
 
     it "overwrites content in an existing file" do
-      FileUtils.mkdir_p(log_dir)
+      FileUtils.mkdir_p(File.dirname(log_file))
       File.open(log_file, File::RDWR | File::CREAT) do |f|
         f.write("Some existing content")
       end
@@ -43,7 +41,7 @@ describe ChefAcceptance::Logger do
 
       logger.log("test-log")
       expect(File.read(log_file)).not_to match("Some existing content")
-      expect(File.read(log_file)).to match(log_format(/Initialized \[.acceptance_logs\/acceptance.log\] logger.../))
+      expect(File.read(log_file)).to match(log_format(/Initialized \[(.*).acceptance_data\/logs\/acceptance.log\] logger.../))
       expect(File.read(log_file)).to match(log_format("test-log"))
     end
   end


### PR DESCRIPTION
This PR adds `--data-path` option which can be used to relocate the temporary chef files and log files created during an chef-acceptance run. 

The default logs directory is now change from `.acceptance_logs` to `.acceptance_data/logs` so that everything can reside under a single directory.

* See https://github.com/chef/chef-acceptance/pull/38 for previous discussion on this.
* Fixes https://github.com/chef/chef-acceptance/issues/36

/cc: @schisamo @patrick-wright 