### PR TITLE
Handle nonsuite directories under the "acceptance" directory gracefully

### DIFF
--- a/lib/chef-acceptance/application.rb
+++ b/lib/chef-acceptance/application.rb
@@ -95,7 +95,11 @@ module ChefAcceptance
       matched_suites = suites.select { |s| /#{regex}/ =~ s }
       raise AcceptanceFatalError, "No matching test suites found using regex '#{regex}'" if matched_suites.empty?
 
-      matched_suites
+      # only select the directories containing the .acceptance under them.
+      # this way we can skip system directories like 'vendor'
+      matched_suites.select do |s|
+        File.directory?(File.join(s, ".acceptance"))
+      end
     end
 
     def run_suite(suite, command)

--- a/lib/chef-acceptance/chef_runner.rb
+++ b/lib/chef-acceptance/chef_runner.rb
@@ -34,7 +34,6 @@ module ChefAcceptance
       prepare_required_files
 
       chef_shellout = build_shellout(
-        cwd: acceptance_cookbook.root_dir,
         chef_config_file: chef_config_file,
         dna_json_file: dna_json_file,
         recipe: recipe
@@ -89,7 +88,6 @@ module ChefAcceptance
     end
 
     def build_shellout(options = {})
-      cwd = options.fetch(:cwd, Dir.pwd)
       recipe = options.fetch(:recipe)
       chef_config_file = options.fetch(:chef_config_file)
       dna_json_file = options.fetch(:dna_json_file)
@@ -102,7 +100,7 @@ module ChefAcceptance
       shellout << "-o #{AcceptanceCookbook::ACCEPTANCE_COOKBOOK_NAME}::#{recipe}"
       shellout << "--no-color"
 
-      Mixlib::ShellOut.new(shellout.join(" "), cwd: cwd, live_stream: suite_logger, timeout: app_options.timeout)
+      Mixlib::ShellOut.new(shellout.join(" "), live_stream: suite_logger, timeout: app_options.timeout)
     end
 
     def data_path

--- a/spec/unit/application_spec.rb
+++ b/spec/unit/application_spec.rb
@@ -15,6 +15,7 @@ describe ChefAcceptance::Application do
     Dir.chdir @acceptance_dir
     suites.each do |suite|
       Dir.mkdir File.join(@acceptance_dir, suite)
+      Dir.mkdir File.join(@acceptance_dir, suite, ".acceptance")
     end
   end
 
@@ -238,6 +239,18 @@ describe ChefAcceptance::Application do
       it "runs multiple suites" do
         expect(app).to receive(:run_suite).twice
         application_run("f", "provision")
+      end
+    end
+
+    context "with a non-suite directory" do
+      before do
+        # create a directory that does not contain an acceptance cookbook.
+        Dir.mkdir File.join(@acceptance_dir, "vendor")
+      end
+
+      it "does not include non-suite directory in the run" do
+        expect(app).to receive(:run_suite).exactly(3).times
+        application_run("", "provision")
       end
     end
 

--- a/spec/unit/chef_runner_spec.rb
+++ b/spec/unit/chef_runner_spec.rb
@@ -41,7 +41,7 @@ describe ChefAcceptance::ChefRunner do
           "-j #{root_dir}/chef/some_suite/provision/dna.json",
           "-o acceptance-cookbook::provision",
           "--no-color",
-        ].join(" "), cwd: root_dir, live_stream: instance_of(ChefAcceptance::Logger), timeout: 7200
+        ].join(" "), live_stream: instance_of(ChefAcceptance::Logger), timeout: 7200
       ).and_return(ccr_shellout)
       expect(ccr_shellout).to receive(:run_command)
       expect(ccr_shellout).to receive(:execution_time).and_return(1)


### PR DESCRIPTION
This PR is motivated by one of the failures in [here](http://manhattan.ci.chef.co/job/chefdk-test/178/architecture=x86_64,platform=acceptance,project=chefdk,role=tester/console) where we try to run `vendor` as a test suite but it is in fact the deployment cache of bundler. We were failing when trying to `cd` into the acceptance cookbook directory under `vendor`. 

My solution is:

1. Only pickup directories that have `.acceptance` under them as suites.
2. Do not `cd` into the cookbook directory to run chef since we are tightly controlling where files get created now. 

/cc: @schisamo @patrick-wright 