### PR TITLE
Exit with non-zero error code when passed an invalid command or an invalid parameter.

### DIFF
--- a/lib/chef-acceptance/cli.rb
+++ b/lib/chef-acceptance/cli.rb
@@ -75,5 +75,11 @@ module ChefAcceptance
       client = ExecutableHelper.executable_installed? "chef-client"
       puts "chef-client path: #{client ? client : "not found in #{ENV['PATH']}"}"
     end
+
+    # By default, Thor returns exit(0) when an error occurs.
+    def self.exit_on_failure?
+      true
+    end
+
   end
 end

--- a/spec/integration/cli_spec.rb
+++ b/spec/integration/cli_spec.rb
@@ -31,6 +31,10 @@ context "ChefAcceptance::Cli" do
     end
   end
 
+  it "exits with non-zero error code" do
+    expect(ChefAcceptance::Cli.exit_on_failure?).to be(true)
+  end
+
   context "for an invalid test suite" do
     let(:options) { %w{provision invalid} }
     let(:failure_expected) { true }

--- a/spec/integration/cli_spec.rb
+++ b/spec/integration/cli_spec.rb
@@ -35,6 +35,28 @@ context "ChefAcceptance::Cli" do
     expect(ChefAcceptance::Cli.exit_on_failure?).to be(true)
   end
 
+  context "with invalid command" do
+    let(:options) { [ "non-existing"] }
+    let(:failure_expected) { true }
+
+    it "exits non-zero" do
+      # Setting :failure_expected is going to check for SystemExit
+      # which means Cli will exit with non-zero exit code
+      run_acceptance
+    end
+  end
+
+  context "with invalid option" do
+    let(:options) { [ "test", "--non-existing" ] }
+    let(:failure_expected) { true }
+
+    it "exits non-zero" do
+      # Setting :failure_expected is going to check for SystemExit
+      # which means Cli will exit with non-zero exit code
+      run_acceptance
+    end
+  end
+
   context "for an invalid test suite" do
     let(:options) { %w{provision invalid} }
     let(:failure_expected) { true }


### PR DESCRIPTION
/cc: @chef/engineering-services 

Fixes https://github.com/chef/chef-acceptance/issues/41