### PR TITLE
stops live streaming and interleaving to stdout

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,23 @@ branches:
   only:
   - master
 
+before_install:
+  - gem install bundler
+  - bundle --version
+  - gem update --system
+  - gem --version
+
+script: bundle exec rake spec
+
 language: ruby
+
 sudo: false
-rvm:
-  - 2.2
-  - 2.1
+
+matrix:
+  include:
+    - rvm: 2.4.1
+    - rvm: 2.3.3
+    - rvm: 2.4.1
+      env:
+        CHEFSTYLE: 1
+      script: bundle exec rake style

--- a/Rakefile
+++ b/Rakefile
@@ -1,18 +1,12 @@
 require "bundler"
 require "bundler/gem_tasks"
-require "rspec/core/rake_task"
 require "rubocop/rake_task"
 
-task default: :test
-
-desc "run unit tests"
-RSpec::Core::RakeTask.new(:unit) do |task|
-  task.pattern = "spec/unit/**/*_spec.rb"
-end
-
-desc "run integration tests"
-RSpec::Core::RakeTask.new(:integration) do |task|
-  task.pattern = "spec/integration/**/*_spec.rb"
+begin
+  require "rspec/core/rake_task"
+  RSpec::Core::RakeTask.new(:spec)
+rescue LoadError
+  puts "rspec is not available."
 end
 
 begin
@@ -22,8 +16,7 @@ begin
     task.options += ["--display-cop-names", "--no-color"]
   end
 rescue LoadError
-  puts "chefstyle/rubocop is not available.  gem install chefstyle to do style checking."
+  puts "chefstyle is not available."
 end
 
-desc "Run all tests"
-task test: [:style, :unit, :integration]
+task default: [ :spec, :style ]

--- a/lib/chef-acceptance/application.rb
+++ b/lib/chef-acceptance/application.rb
@@ -48,7 +48,7 @@ module ChefAcceptance
         work_queue = Queue.new
         suites.each { |s| work_queue << [s, command] }
 
-        workers = WORKER_POOL_SIZE.times.map do |_i|
+        workers = Array.new(WORKER_POOL_SIZE) do |_i|
           start_worker(work_queue)
         end
 

--- a/lib/chef-acceptance/application.rb
+++ b/lib/chef-acceptance/application.rb
@@ -151,6 +151,7 @@ module ChefAcceptance
         error = true
         raise
       ensure
+        runner.send_log_to_stdout
         output_formatter.add_row(suite: test_suite.name, command: command, duration: runner.duration, error: error)
       end
     end

--- a/lib/chef-acceptance/chef_runner.rb
+++ b/lib/chef-acceptance/chef_runner.rb
@@ -27,7 +27,7 @@ module ChefAcceptance
       @log_path = File.join(app_options.data_path, "logs", test_suite.name, "#{recipe}.log")
       @suite_logger = ChefAcceptance::Logger.new(
         log_header: "#{test_suite.name.upcase}::#{recipe.upcase}",
-        log_path: log_path,
+        log_path: log_path
       )
     end
 

--- a/lib/chef-acceptance/chef_runner.rb
+++ b/lib/chef-acceptance/chef_runner.rb
@@ -27,7 +27,8 @@ module ChefAcceptance
       @log_path = File.join(app_options.data_path, "logs", test_suite.name, "#{recipe}.log")
       @suite_logger = ChefAcceptance::Logger.new(
         log_header: "#{test_suite.name.upcase}::#{recipe.upcase}",
-        log_path: log_path
+        log_path: log_path,
+        stdout: false
       )
     end
 
@@ -57,7 +58,7 @@ module ChefAcceptance
     end
 
     def send_log_to_stdout
-      puts IO.read(log_path)
+      $stdout.write IO.read(log_path)
     end
 
     private

--- a/lib/chef-acceptance/chef_runner.rb
+++ b/lib/chef-acceptance/chef_runner.rb
@@ -16,6 +16,7 @@ module ChefAcceptance
     attr_reader :duration
     attr_reader :app_options
     attr_reader :suite_logger
+    attr_reader :log_path
 
     def initialize(test_suite, recipe, app_options)
       @test_suite = test_suite
@@ -23,9 +24,10 @@ module ChefAcceptance
       @recipe = recipe
       @duration = 0
       @app_options = app_options
+      @log_path = File.join(app_options.data_path, "logs", test_suite.name, "#{recipe}.log")
       @suite_logger = ChefAcceptance::Logger.new(
         log_header: "#{test_suite.name.upcase}::#{recipe.upcase}",
-        log_path: File.join(app_options.data_path, "logs", test_suite.name, "#{recipe}.log")
+        log_path: log_path,
       )
     end
 
@@ -52,6 +54,10 @@ module ChefAcceptance
         @duration = chef_shellout.execution_time || 0
         chef_shellout.error! # This will only raise an error if there was one
       end
+    end
+
+    def send_log_to_stdout
+      puts IO.read(log_path)
     end
 
     private

--- a/lib/chef-acceptance/logger.rb
+++ b/lib/chef-acceptance/logger.rb
@@ -5,7 +5,6 @@ module ChefAcceptance
     attr_reader :log_path
     attr_reader :log_header
     attr_reader :file_logger
-    attr_reader :stdout_logger
 
     # Supported options:
     # log_path: full path to the log file
@@ -18,7 +17,6 @@ module ChefAcceptance
       FileUtils.mkdir_p(File.dirname(log_path))
 
       @file_logger = create_file_logger
-      @stdout_logger = create_stdout_logger
 
       log("Initialized [#{options[:log_path]}] logger...")
     end
@@ -26,7 +24,6 @@ module ChefAcceptance
     # logs given message to the acceptance logs and stdout
     def log(message)
       file_logger.info(message)
-      stdout_logger.info(message)
     end
 
     alias_method :<<, :log
@@ -39,10 +36,6 @@ module ChefAcceptance
       log_file.sync = true
 
       format_logger_for_acceptance(::Logger.new(log_file))
-    end
-
-    def create_stdout_logger
-      format_logger_for_acceptance(::Logger.new($stdout))
     end
 
     def format_logger_for_acceptance(logger)

--- a/lib/chef-acceptance/logger.rb
+++ b/lib/chef-acceptance/logger.rb
@@ -5,25 +5,32 @@ module ChefAcceptance
     attr_reader :log_path
     attr_reader :log_header
     attr_reader :file_logger
+    attr_reader :stdout_logger
 
     # Supported options:
     # log_path: full path to the log file
     # log_header: the prefix logger will print when logging messages.
-    def initialize(options = {})
-      @log_header = options.fetch(:log_header)
-      @log_path = options.fetch(:log_path)
+    # stdout: create stdout logger to stream to stdout when true
+    def initialize(log_header: "", log_path: "", stdout: true)
+      @log_header = log_header
+      @log_path = log_path
 
       # create the main logs directory
       FileUtils.mkdir_p(File.dirname(log_path))
 
       @file_logger = create_file_logger
 
-      log("Initialized [#{options[:log_path]}] logger...")
+      if stdout
+        @stdout_logger = create_stdout_logger
+      end
+
+      log("Initialized [#{log_path}] logger...")
     end
 
     # logs given message to the acceptance logs and stdout
     def log(message)
       file_logger.info(message)
+      stdout_logger.info(message) if stdout_logger
     end
 
     alias_method :<<, :log
@@ -36,6 +43,10 @@ module ChefAcceptance
       log_file.sync = true
 
       format_logger_for_acceptance(::Logger.new(log_file))
+    end
+
+    def create_stdout_logger
+      format_logger_for_acceptance(::Logger.new($stdout))
     end
 
     def format_logger_for_acceptance(logger)

--- a/spec/integration/chef_runner_spec.rb
+++ b/spec/integration/chef_runner_spec.rb
@@ -9,7 +9,10 @@ context ChefAcceptance::ChefRunner do
   let(:runner) { ChefAcceptance::ChefRunner.new(test_suite, "provision", options_instance) }
 
   def run
-    capture(:stdout) { runner.run! }
+    capture(:stdout) do
+      runner.run!
+      runner.send_log_to_stdout
+    end
   end
 
   it "calls run" do

--- a/spec/integration/cli_spec.rb
+++ b/spec/integration/cli_spec.rb
@@ -13,9 +13,9 @@ context "ChefAcceptance::Cli" do
 
   let(:failure_expected) { false }
   let(:acceptance_data_path) { File.join(ACCEPTANCE_TEST_DIRECTORY, ".acceptance_data") }
-  let(:acceptance_log) {
+  let(:acceptance_log) do
     File.read(File.join(acceptance_data_path, "logs", "acceptance.log"))
-  }
+  end
 
   def suite_log_for(suite_name, command)
     File.read(File.join(acceptance_data_path, "logs", suite_name, "#{command}.log"))

--- a/spec/unit/application_spec.rb
+++ b/spec/unit/application_spec.rb
@@ -130,6 +130,7 @@ describe ChefAcceptance::Application do
             end
 
             allow(runner).to receive(:duration).and_return(10)
+            allow(runner).to receive(:send_log_to_stdout)
 
             expect(ChefAcceptance::ChefRunner).to receive(:new)
               .with(kind_of(ChefAcceptance::TestSuite), c, kind_of(ChefAcceptance::Options)).and_return(runner)
@@ -166,6 +167,7 @@ describe ChefAcceptance::Application do
           end
 
           allow(runner).to receive(:duration).and_return(10)
+          allow(runner).to receive(:send_log_to_stdout)
 
           expected_commands.each do |c|
             expect(ChefAcceptance::ChefRunner).to receive(:new).ordered

--- a/spec/unit/application_spec.rb
+++ b/spec/unit/application_spec.rb
@@ -6,9 +6,9 @@ describe ChefAcceptance::Application do
   let(:app_options) { {} }
   let(:failure_expected) { false }
   let(:suites) { [] }
-  let(:acceptance_log) {
+  let(:acceptance_log) do
     File.read(File.join(@acceptance_dir, ".acceptance_data", "logs", "acceptance.log"))
-  }
+  end
 
   before do
     @acceptance_dir = Dir.mktmpdir

--- a/spec/unit/output_formatter_spec.rb
+++ b/spec/unit/output_formatter_spec.rb
@@ -3,11 +3,11 @@ require "chef-acceptance/output_formatter"
 
 describe ChefAcceptance::OutputFormatter do
   let(:formatter) { ChefAcceptance::OutputFormatter.new }
-  let(:test_rows) {
+  let(:test_rows) do
     unformatted_rows.map do |row|
       row = { suite: row[0], command: row[1], duration: row[2], error: row[3] }
     end
-  }
+  end
 
   context "when there are no rows" do
     let(:unformatted_rows) { [] }
@@ -21,11 +21,11 @@ describe ChefAcceptance::OutputFormatter do
   end
 
   context "when there is a single row" do
-    let(:unformatted_rows) {
+    let(:unformatted_rows) do
       [
         ["suite2", "destroy", 10000000000, false],
       ]
-    }
+    end
 
     it "outputs successfully" do
       test_rows.each do |r|
@@ -40,7 +40,7 @@ describe ChefAcceptance::OutputFormatter do
   end
 
   context "when there are many rows" do
-    let(:unformatted_rows) {
+    let(:unformatted_rows) do
       [
         ["suite1", "provision", 1, false],
         ["suite1", "verify", 1000, true],
@@ -49,7 +49,7 @@ describe ChefAcceptance::OutputFormatter do
         ["suite2", "verify", 1000000, false],
         ["suite2", "destroy", 10000000000, false],
       ]
-    }
+    end
 
     it "outputs successfully" do
       test_rows.each do |r|


### PR DESCRIPTION
when the process exits we pick up the logfile and puke it all out at
once to stdout.

threads might race here and we could rub some mutex on it, but i'm super
not worried about perfection right now.

bonus travis and Rakefile modernization along with some chefstyle fixes

refactored slightly so that the main thread / main logger live streams to stdout while the worker processes buffer to their logfiles

Signed-off-by: Lamont Granquist <lamont@scriptkiddie.org>